### PR TITLE
Update runner to macos-26

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 30
 
     env:


### PR DESCRIPTION
- Update runner from macos-15 to macos-26 for iOS 26 SDK requirement
- Apple requires iOS 26 SDK starting April 28, 2026