### PR TITLE
Add performance baseline

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,62 @@
+name: Performance
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  baseline:
+    runs-on: macos-26
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Write Secrets.json
+        run: printf '{"IPINFO_KEY":"%s"}' "$IPINFO_KEY" > ScoutIP/Resources/Secrets.json
+        env:
+          IPINFO_KEY: ${{ secrets.IPINFO_KEY }}
+
+      - name: Build
+        run: |
+          xcodebuild build \
+            -project ScoutIP.xcodeproj \
+            -scheme ScoutIP \
+            -destination 'platform=iOS Simulator,name=iPhone 17' \
+            -derivedDataPath $RUNNER_TEMP/DerivedData
+
+      - name: Boot simulator
+        run: |
+          xcrun simctl boot "iPhone 17" || true
+          xcrun simctl bootstatus "iPhone 17" -b
+
+      - name: Install app
+        run: |
+          APP_PATH=$(find $RUNNER_TEMP/DerivedData -name "ScoutIP.app" -path "*/Debug-iphonesimulator/*" | head -1)
+          xcrun simctl install booted "$APP_PATH"
+
+      - name: Measure launch time
+        run: |
+          echo "## Performance Report" >> $GITHUB_STEP_SUMMARY
+          echo "| Run | Launch Time |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----|-------------|" >> $GITHUB_STEP_SUMMARY
+
+          for i in 1 2 3; do
+            xcrun simctl terminate booted com.kasianov.ScoutIP 2>/dev/null || true
+            sleep 2
+
+            START=$(python3 -c "import time; print(int(time.time()*1000))")
+            xcrun simctl launch booted com.kasianov.ScoutIP
+            sleep 5
+            END=$(python3 -c "import time; print(int(time.time()*1000))")
+
+            DURATION=$((END - START))
+            echo "| $i | ${DURATION}ms |" >> $GITHUB_STEP_SUMMARY
+            echo "Launch $i: ${DURATION}ms"
+          done
+
+      - name: Measure binary size
+        run: |
+          APP_PATH=$(find $RUNNER_TEMP/DerivedData -name "ScoutIP.app" -path "*/Debug-iphonesimulator/*" | head -1)
+          BINARY_SIZE=$(stat -f%z "$APP_PATH/ScoutIP")
+          echo "| Binary size | $(echo "scale=2; $BINARY_SIZE/1048576" | bc)MB |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Measure app launch time (3 runs) and binary size on each push to main
- Reports results in CI step summary for tracking degradation over time