### PR TITLE
Add network mocking for UI tests

### DIFF
--- a/ScoutIP/Search/MockProvider.swift
+++ b/ScoutIP/Search/MockProvider.swift
@@ -1,0 +1,24 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+
+enum MockProvider {
+
+    static var isMocking: Bool {
+        ProcessInfo.processInfo.arguments.contains("-UITestMocking")
+    }
+
+    static let mockIP = "8.8.8.8"
+    static let mockCity = "Mountain View"
+    static let mockRegion = "California"
+    static let mockCountry = "US"
+    static let mockLocation = "37.3861,-122.0839"
+    static let mockOrg = "AS15169 Google LLC"
+    static let mockPostal = "94035"
+    static let mockTimezone = "America/Los_Angeles"
+}

--- a/ScoutIPUITests/ScoutIPUITests.swift
+++ b/ScoutIPUITests/ScoutIPUITests.swift
@@ -13,6 +13,7 @@ final class ScoutIPUITests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
+        app.launchArguments += ["-UITestMocking"]
         app.launch()
     }
 


### PR DESCRIPTION
- Add MockProvider with deterministic test data
- Enable mocking via -UITestMocking launch argument
- Set launch argument in UI tests