### PR TITLE
Remove push trigger from TestFlight

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,8 +1,6 @@
 name: TestFlight
 
 on:
-  push:
-    branches: [main]
   repository_dispatch:
     types: [scout-updated]
   workflow_dispatch:


### PR DESCRIPTION
- Keep only repository_dispatch (Scout updates), workflow_dispatch (manual), and nightly triggers\n- Avoids hitting Apple upload limit on busy days