### PR TITLE
Use accessibility identifiers in UI tests

### DIFF
--- a/ScoutIPUITests/DarkModeTests.swift
+++ b/ScoutIPUITests/DarkModeTests.swift
@@ -20,8 +20,8 @@ final class DarkModeTests: XCTestCase {
     app.launchArguments += ["-UIUserInterfaceStyle", "Dark"]
     app.launch()
 
-    XCTAssertTrue(app.tabBars.buttons["Info"].waitForExistence(timeout: 2))
-    XCTAssertTrue(app.tabBars.buttons["History"].exists)
+    XCTAssertTrue(app.tabBars.buttons["InfoTab"].waitForExistence(timeout: 2))
+    XCTAssertTrue(app.tabBars.buttons["HistoryTab"].exists)
   }
 
   @MainActor
@@ -29,11 +29,11 @@ final class DarkModeTests: XCTestCase {
     app.launchArguments += ["-UIUserInterfaceStyle", "Dark"]
     app.launch()
 
-    app.tabBars.buttons["History"].tap()
-    XCTAssertTrue(app.navigationBars["History"].waitForExistence(timeout: 2))
+    app.tabBars.buttons["HistoryTab"].tap()
+    XCTAssertTrue(app.navigationBars["HistoryTab"].waitForExistence(timeout: 2))
 
-    app.tabBars.buttons["Info"].tap()
-    XCTAssertTrue(app.navigationBars["Info"].waitForExistence(timeout: 2))
+    app.tabBars.buttons["InfoTab"].tap()
+    XCTAssertTrue(app.navigationBars["InfoTab"].waitForExistence(timeout: 2))
   }
 
   @MainActor

--- a/ScoutIPUITests/ScoutIPUITests.swift
+++ b/ScoutIPUITests/ScoutIPUITests.swift
@@ -21,14 +21,14 @@ final class ScoutIPUITests: XCTestCase {
 
   @MainActor
   func testTabNavigation() {
-    XCTAssertTrue(app.tabBars.buttons["Info"].exists)
-    XCTAssertTrue(app.tabBars.buttons["History"].exists)
+    XCTAssertTrue(app.tabBars.buttons["InfoTab"].exists)
+    XCTAssertTrue(app.tabBars.buttons["HistoryTab"].exists)
 
-    app.tabBars.buttons["History"].tap()
-    XCTAssertTrue(app.navigationBars["History"].waitForExistence(timeout: 2))
+    app.tabBars.buttons["HistoryTab"].tap()
+    XCTAssertTrue(app.navigationBars["HistoryTab"].waitForExistence(timeout: 2))
 
-    app.tabBars.buttons["Info"].tap()
-    XCTAssertTrue(app.navigationBars["Info"].waitForExistence(timeout: 2))
+    app.tabBars.buttons["InfoTab"].tap()
+    XCTAssertTrue(app.navigationBars["InfoTab"].waitForExistence(timeout: 2))
   }
 
   // MARK: - Search
@@ -82,7 +82,7 @@ final class ScoutIPUITests: XCTestCase {
     wait(for: [tableExpectation], timeout: 10)
 
     // Switch to History
-    app.tabBars.buttons["History"].tap()
+    app.tabBars.buttons["HistoryTab"].tap()
 
     let historyPredicate = NSPredicate(format: "cells.count > 0")
     let historyExpectation = XCTNSPredicateExpectation(
@@ -92,7 +92,7 @@ final class ScoutIPUITests: XCTestCase {
 
   @MainActor
   func testHistoryFilterSegments() {
-    app.tabBars.buttons["History"].tap()
+    app.tabBars.buttons["HistoryTab"].tap()
 
     XCTAssertTrue(app.buttons["all"].waitForExistence(timeout: 2))
     XCTAssertTrue(app.buttons["user"].exists)

--- a/ScoutIPUITests/SnapshotTests.swift
+++ b/ScoutIPUITests/SnapshotTests.swift
@@ -27,7 +27,7 @@ final class SnapshotTests: XCTestCase {
 
   @MainActor
   func testHistoryScreenSnapshot() {
-    app.tabBars.buttons["History"].tap()
+    app.tabBars.buttons["HistoryTab"].tap()
 
     let screenshot = app.screenshot()
     let attachment = XCTAttachment(screenshot: screenshot)
@@ -55,7 +55,7 @@ final class SnapshotTests: XCTestCase {
     app.launchArguments += ["-UIUserInterfaceStyle", "Dark"]
     app.launch()
 
-    app.tabBars.buttons["History"].tap()
+    app.tabBars.buttons["HistoryTab"].tap()
 
     let screenshot = app.screenshot()
     let attachment = XCTAttachment(screenshot: screenshot)


### PR DESCRIPTION
- Replace tab bar text matching with InfoTab/HistoryTab accessibility identifiers