### PR TITLE
Add empty state illustrations

### DIFF
--- a/ScoutIP/Components/EmptyStateView.swift
+++ b/ScoutIP/Components/EmptyStateView.swift
@@ -1,0 +1,32 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import SwiftUI
+
+struct EmptyStateView: View {
+  let icon: String
+  let title: String
+  let subtitle: String
+
+  var body: some View {
+    VStack(spacing: 12) {
+      Image(systemName: icon)
+        .font(.system(size: 48))
+        .foregroundStyle(.tertiary)
+      Text(title)
+        .font(.headline)
+        .foregroundStyle(.secondary)
+      Text(subtitle)
+        .font(.subheadline)
+        .foregroundStyle(.tertiary)
+        .multilineTextAlignment(.center)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 40)
+    .listRowBackground(Color.clear)
+  }
+}

--- a/ScoutIP/History/HistoryIPList.swift
+++ b/ScoutIP/History/HistoryIPList.swift
@@ -32,10 +32,11 @@ struct HistoryIPList: View {
     }
     .overlay {
       if records.isEmpty {
-        Text("NO DATA")
-          .font(.system(size: 14, weight: .medium, design: .default))
-          .foregroundColor(.gray)
-          .frame(maxHeight: .infinity)
+        EmptyStateView(
+          icon: "magnifyingglass",
+          title: "NO DATA",
+          subtitle: "No records for this IP"
+        )
       }
     }
     .toolbar {

--- a/ScoutIP/History/HistoryList.swift
+++ b/ScoutIP/History/HistoryList.swift
@@ -78,7 +78,11 @@ struct HistoryList: View {
       .overlay {
         if history.isEmpty {
           VStack(spacing: 8) {
-            Text("NO DATA")
+            EmptyStateView(
+              icon: "clock.arrow.circlepath",
+              title: "NO DATA",
+              subtitle: "Search for an IP to see history"
+            )
               .font(.system(size: 14, weight: .medium))
 
             if records.count > 0 {


### PR DESCRIPTION
- Replace plain text with icon, title, and subtitle in empty states\n- Applied to History and IP History screens