### PR TITLE
Add stress tests to debug menu

### DIFF
--- a/ScoutIP/Components/CrashTestView.swift
+++ b/ScoutIP/Components/CrashTestView.swift
@@ -12,6 +12,8 @@ import SwiftUI
 struct DebugView: View {
   @State private var logCount = 0
   @State private var metricCount = 0
+  @State private var stressRunning = false
+  @State private var stressProgress = 0
 
   var body: some View {
     List {
@@ -51,6 +53,27 @@ struct DebugView: View {
           .foregroundStyle(.secondary)
       }
 
+      Section("Stress Test") {
+        Button(stressRunning ? "Running..." : "Log 1000 events") {
+          runStress(count: 1000)
+        }
+        .disabled(stressRunning)
+
+        Button(stressRunning ? "Running..." : "Log 100 + 100 metrics") {
+          runMixedStress()
+        }
+        .disabled(stressRunning)
+
+        Button("Rapid fire (10 per second for 30s)") {
+          runRapidFire()
+        }
+        .disabled(stressRunning)
+
+        if stressRunning {
+          ProgressView(value: Double(stressProgress), total: 100)
+        }
+      }
+
       Section("Crash") {
         Button("NSGenericException") {
           NSException(name: .genericException, reason: "Test crash", userInfo: nil).raise()
@@ -66,5 +89,70 @@ struct DebugView: View {
       }
     }
     .navigationTitle("Debug")
+  }
+
+  func runStress(count: Int) {
+    stressRunning = true
+    stressProgress = 0
+    let logger = Logger(label: "StressTest")
+
+    Task {
+      for i in 1...count {
+        let level: Logger.Level = [.info, .warning, .error, .debug].randomElement()!
+        logger.log(level: level, "Stress event \(i) of \(count)")
+
+        if i % (count / 100) == 0 {
+          stressProgress = i * 100 / count
+        }
+
+        if i % 50 == 0 {
+          try? await Task.sleep(for: .milliseconds(10))
+        }
+      }
+      logCount += count
+      stressRunning = false
+    }
+  }
+
+  func runMixedStress() {
+    stressRunning = true
+    stressProgress = 0
+    let logger = Logger(label: "StressTest")
+
+    Task {
+      for i in 1...100 {
+        logger.info("Mixed stress log \(i)")
+        Counter(label: "stress_counter_\(i % 5)").increment()
+        Timer(label: "stress_timer").recordSeconds(Double.random(in: 0.01...2.0))
+
+        stressProgress = i
+        if i % 10 == 0 {
+          try? await Task.sleep(for: .milliseconds(10))
+        }
+      }
+      logCount += 100
+      metricCount += 200
+      stressRunning = false
+    }
+  }
+
+  func runRapidFire() {
+    stressRunning = true
+    stressProgress = 0
+    let logger = Logger(label: "RapidFire")
+
+    Task {
+      for second in 1...30 {
+        for burst in 1...10 {
+          logger.info("Rapid fire s\(second) b\(burst)")
+        }
+        Counter(label: "rapid_fire").increment(by: 10)
+        stressProgress = second * 100 / 30
+        try? await Task.sleep(for: .seconds(1))
+      }
+      logCount += 300
+      metricCount += 30
+      stressRunning = false
+    }
   }
 }


### PR DESCRIPTION
- Log 1000 events at once to test Scout under load\n- Mixed stress: 100 logs + 100 metrics simultaneously\n- Rapid fire: 10 events per second for 30 seconds\n- Progress bar during stress tests