### PR TITLE
Add workspace for local Scout development

### DIFF
--- a/ScoutIP.xcworkspace/contents.xcworkspacedata
+++ b/ScoutIP.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "container:ScoutIP.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:../scout">
+   </FileRef>
+</Workspace>

--- a/ScoutIP.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ScoutIP.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "8146b52b686ef86b233426688ef013d889a0bca91c7c717e1e3488ea17903620",
+  "pins" : [
+    {
+      "identity" : "scout",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kasianov-mikhail/scout",
+      "state" : {
+        "branch" : "main",
+        "revision" : "82d68de8e4ab2430d2ce5da1dd7baf3c281f3de3"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "c6593dac9d65f2517280d88c430dadffdf259737",
+        "version" : "2.10.0"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
- Add xcworkspace that references ../scout for local package development\n- Falls back to remote Scout when local folder is absent\n- CI continues using xcodeproj unchanged