### PR TITLE
Fix UI test identifiers

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -54,7 +54,7 @@ jobs:
 
   ui-tests:
     runs-on: macos-26
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@v6

--- a/ScoutIPUITests/DarkModeTests.swift
+++ b/ScoutIPUITests/DarkModeTests.swift
@@ -20,8 +20,8 @@ final class DarkModeTests: XCTestCase {
     app.launchArguments += ["-UIUserInterfaceStyle", "Dark"]
     app.launch()
 
-    XCTAssertTrue(app.tabBars.buttons["InfoTab"].waitForExistence(timeout: 2))
-    XCTAssertTrue(app.tabBars.buttons["HistoryTab"].exists)
+    XCTAssertTrue(app.tabBars.buttons["Info"].waitForExistence(timeout: 2))
+    XCTAssertTrue(app.tabBars.buttons["History"].exists)
   }
 
   @MainActor
@@ -29,11 +29,11 @@ final class DarkModeTests: XCTestCase {
     app.launchArguments += ["-UIUserInterfaceStyle", "Dark"]
     app.launch()
 
-    app.tabBars.buttons["HistoryTab"].tap()
-    XCTAssertTrue(app.navigationBars["HistoryTab"].waitForExistence(timeout: 2))
+    app.tabBars.buttons["History"].tap()
+    XCTAssertTrue(app.navigationBars["History"].waitForExistence(timeout: 2))
 
-    app.tabBars.buttons["InfoTab"].tap()
-    XCTAssertTrue(app.navigationBars["InfoTab"].waitForExistence(timeout: 2))
+    app.tabBars.buttons["Info"].tap()
+    XCTAssertTrue(app.navigationBars["Info"].waitForExistence(timeout: 2))
   }
 
   @MainActor

--- a/ScoutIPUITests/ScoutIPUITests.swift
+++ b/ScoutIPUITests/ScoutIPUITests.swift
@@ -21,14 +21,14 @@ final class ScoutIPUITests: XCTestCase {
 
   @MainActor
   func testTabNavigation() {
-    XCTAssertTrue(app.tabBars.buttons["InfoTab"].exists)
-    XCTAssertTrue(app.tabBars.buttons["HistoryTab"].exists)
+    XCTAssertTrue(app.tabBars.buttons["Info"].exists)
+    XCTAssertTrue(app.tabBars.buttons["History"].exists)
 
-    app.tabBars.buttons["HistoryTab"].tap()
-    XCTAssertTrue(app.navigationBars["HistoryTab"].waitForExistence(timeout: 2))
+    app.tabBars.buttons["History"].tap()
+    XCTAssertTrue(app.navigationBars["History"].waitForExistence(timeout: 2))
 
-    app.tabBars.buttons["InfoTab"].tap()
-    XCTAssertTrue(app.navigationBars["InfoTab"].waitForExistence(timeout: 2))
+    app.tabBars.buttons["Info"].tap()
+    XCTAssertTrue(app.navigationBars["Info"].waitForExistence(timeout: 2))
   }
 
   // MARK: - Search
@@ -50,9 +50,7 @@ final class ScoutIPUITests: XCTestCase {
     let searchButton = app.buttons["IP Search Button"]
     searchButton.tap()
 
-    let predicate = NSPredicate(format: "cells.count > 0")
-    let expectation = XCTNSPredicateExpectation(predicate: predicate, object: app.tables.firstMatch)
-    wait(for: [expectation], timeout: 10)
+    XCTAssertTrue(app.cells.firstMatch.waitForExistence(timeout: 10))
   }
 
   @MainActor
@@ -64,9 +62,7 @@ final class ScoutIPUITests: XCTestCase {
     let searchButton = app.buttons["IP Search Button"]
     searchButton.tap()
 
-    let predicate = NSPredicate(format: "cells.count > 0")
-    let expectation = XCTNSPredicateExpectation(predicate: predicate, object: app.tables.firstMatch)
-    wait(for: [expectation], timeout: 10)
+    XCTAssertTrue(app.cells.firstMatch.waitForExistence(timeout: 10))
   }
 
   // MARK: - History
@@ -76,31 +72,25 @@ final class ScoutIPUITests: XCTestCase {
     // Search first to create a record
     app.buttons["IP Search Button"].tap()
 
-    let predicate = NSPredicate(format: "cells.count > 0")
-    let tableExpectation = XCTNSPredicateExpectation(
-      predicate: predicate, object: app.tables.firstMatch)
-    wait(for: [tableExpectation], timeout: 10)
+    XCTAssertTrue(app.cells.firstMatch.waitForExistence(timeout: 10))
 
     // Switch to History
-    app.tabBars.buttons["HistoryTab"].tap()
+    app.tabBars.buttons["History"].tap()
 
-    let historyPredicate = NSPredicate(format: "cells.count > 0")
-    let historyExpectation = XCTNSPredicateExpectation(
-      predicate: historyPredicate, object: app.tables.firstMatch)
-    wait(for: [historyExpectation], timeout: 5)
+    XCTAssertTrue(app.cells.firstMatch.waitForExistence(timeout: 5))
   }
 
   @MainActor
   func testHistoryFilterSegments() {
-    app.tabBars.buttons["HistoryTab"].tap()
+    app.tabBars.buttons["History"].tap()
 
-    XCTAssertTrue(app.buttons["all"].waitForExistence(timeout: 2))
-    XCTAssertTrue(app.buttons["user"].exists)
-    XCTAssertTrue(app.buttons["search"].exists)
+    XCTAssertTrue(app.buttons["All"].waitForExistence(timeout: 2))
+    XCTAssertTrue(app.buttons["User"].exists)
+    XCTAssertTrue(app.buttons["Search"].exists)
 
-    app.buttons["user"].tap()
-    app.buttons["search"].tap()
-    app.buttons["all"].tap()
+    app.buttons["User"].tap()
+    app.buttons["Search"].tap()
+    app.buttons["All"].tap()
   }
 
   // MARK: - Launch Performance

--- a/ScoutIPUITests/SnapshotTests.swift
+++ b/ScoutIPUITests/SnapshotTests.swift
@@ -27,7 +27,7 @@ final class SnapshotTests: XCTestCase {
 
   @MainActor
   func testHistoryScreenSnapshot() {
-    app.tabBars.buttons["HistoryTab"].tap()
+    app.tabBars.buttons["History"].tap()
 
     let screenshot = app.screenshot()
     let attachment = XCTAttachment(screenshot: screenshot)
@@ -55,7 +55,7 @@ final class SnapshotTests: XCTestCase {
     app.launchArguments += ["-UIUserInterfaceStyle", "Dark"]
     app.launch()
 
-    app.tabBars.buttons["HistoryTab"].tap()
+    app.tabBars.buttons["History"].tap()
 
     let screenshot = app.screenshot()
     let attachment = XCTAttachment(screenshot: screenshot)


### PR DESCRIPTION
- Fix tab bar button identifiers: use label text (`Info`/`History`) instead of content view accessibility identifiers (`InfoTab`/`HistoryTab`)
- Fix navigation bar identifiers to match actual navigation titles
- Fix filter segment button identifiers to use capitalized text (`All`/`User`/`Search`)
- Replace `app.tables.firstMatch` with `app.cells.firstMatch` for iOS 26 compatibility (SwiftUI List renders as UICollectionView)