### PR TITLE
Add workflow_dispatch to Build Matrix

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
- Allow manual trigger of the Build Matrix workflow via Actions UI or `gh workflow run`