### PR TITLE
Cancel outdated workflow runs automatically

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: macos-26

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -5,6 +5,10 @@ on:
     types: [scout-updated]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: macos-26


### PR DESCRIPTION
- Add concurrency groups to Build Matrix and TestFlight workflows
- New pushes to the same branch/PR automatically cancel in-progress runs