### PR TITLE
Increase What to Test retry timeout

### DIFF
--- a/.github/scripts/set-whats-new.py
+++ b/.github/scripts/set-whats-new.py
@@ -46,7 +46,7 @@ def api_request(url, method="GET", body=None):
 
 
 def find_build():
-    for attempt in range(10):
+    for attempt in range(20):
         try:
             resp = api_request(
                 f"https://api.appstoreconnect.apple.com/v1/builds"

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -5,6 +5,10 @@ on:
     types: [scout-updated]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: macos-26
@@ -130,6 +134,9 @@ jobs:
             echo "$OUTPUT"
             if echo "$OUTPUT" | grep -q "CFBundleShortVersionString"; then
               echo "needs_bump=true" >> $GITHUB_OUTPUT
+            elif echo "$OUTPUT" | grep -q "agreement"; then
+              echo "::error::A required agreement is missing or has expired. Accept it at https://appstoreconnect.apple.com/agreements"
+              exit 1
             else
               exit 1
             fi


### PR DESCRIPTION
- Increase retry attempts from 10 to 20 (5 min → 10 min) to allow more time for App Store Connect build processing