### PR TITLE
Add Auto Fix workflow for failed builds

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -1,0 +1,34 @@
+name: Auto Fix
+
+on:
+  workflow_run:
+    workflows: [Build Matrix]
+    types: [completed]
+
+jobs:
+  fix:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt: |
+            The "Build Matrix" workflow failed.
+            Run ID: ${{ github.event.workflow_run.id }}
+            Branch: ${{ github.event.workflow_run.head_branch }}
+
+            1. Run `gh run view ${{ github.event.workflow_run.id }} --log-failed` to get the failure logs
+            2. Diagnose the root cause
+            3. If the fix is in code or CI config, make the changes and create a PR targeting the failed branch
+            4. If the failure is environmental (network, Apple services, flaky test), just post a summary comment on the run
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowedTools: "Bash,Read,Write,Edit,Glob,Grep"


### PR DESCRIPTION
- Trigger Claude Code on Build Matrix failures to diagnose and fix automatically
- Creates a PR with the fix or posts a summary if the failure is environmental
- Requires `ANTHROPIC_API_KEY` secret