### PR TITLE
Add id-token permission to Auto Fix workflow

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -15,6 +15,7 @@ jobs:
       contents: write
       pull-requests: write
       actions: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
- Add `id-token: write` permission required by claude-code-action for OIDC authentication