### PR TITLE
Remove brew install xcbeautify

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -42,9 +42,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install xcbeautify
-        run: brew install xcbeautify
-
       - name: Prepare simulator
         run: |
           if ! xcrun simctl list devices available | grep -q "iPhone"; then

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -89,9 +89,6 @@ jobs:
         env:
           APP_STORE_CONNECT_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
 
-      - name: Install xcbeautify
-        run: brew install xcbeautify
-
       - name: Archive
         run: |
           set -o pipefail


### PR DESCRIPTION
- xcbeautify is preinstalled on GitHub macOS runners, no need to install via brew