### PR TITLE
Replace nightly with hourly conditional TestFlight

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,16 +1,32 @@
-name: Nightly
+name: Hourly
 
 on:
   schedule:
-    - cron: '0 4 * * *'
+    - cron: '0 * * * *'
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Trigger TestFlight build
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for new commits
+        id: changes
         run: |
-          gh workflow run testflight.yml --repo ${{ github.repository }}
+          LAST_TAG=$(git tag --sort=-creatordate | head -1)
+          if [ -z "$LAST_TAG" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          elif [ "$(git rev-parse HEAD)" != "$(git rev-parse "$LAST_TAG"^{commit} 2>/dev/null)" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Trigger TestFlight
+        if: steps.changes.outputs.has_changes == 'true'
+        run: gh workflow run testflight.yml --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
- Run every hour instead of once per day
- Compare HEAD with last tag to detect new commits
- Only trigger TestFlight if there are changes since last build