### PR TITLE
Fix Scout dependency update in TestFlight workflow

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
+          rm ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
           xcodebuild -resolvePackageDependencies -project ScoutIP.xcodeproj
           if git diff --quiet; then
             echo "No dependency changes"


### PR DESCRIPTION
- Delete Package.resolved before resolvePackageDependencies so SPM fetches the latest commit from scout main branch
- Previously resolvePackageDependencies validated the existing Package.resolved without updating it, so scout-ip never picked up new scout commits