### PR TITLE
Use personal git identity for automated commits

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -28,6 +28,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           rm ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
           xcodebuild -resolvePackageDependencies -project ScoutIP.xcodeproj
           if git diff --quiet; then

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -28,8 +28,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "Mikhail Kasianov"
+          git config user.email "96941969+kasianov-mikhail@users.noreply.github.com"
           rm ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
           xcodebuild -resolvePackageDependencies -project ScoutIP.xcodeproj
           if git diff --quiet; then


### PR DESCRIPTION
- Configure git user as kasianov-mikhail in TestFlight workflow so automated commits are properly attributed instead of using the macOS runner default (Anka)