### PR TITLE
Add --auto flag to bump version merge and simplify workflow docs

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -2,21 +2,16 @@
 
 ## Build Matrix
 
-Runs on every push to `main` and on pull requests. Lints code with `swift-format` and builds the app on a matrix of simulators (iPhone 16/iOS 18, iPhone 17/iOS 26, iPhone 17 Pro Max/iOS 26). Acts as a quality gate — branch protection requires all checks to pass before merging.
+Lints and builds the app on a matrix of simulators. Required to pass before merging.
 
 ## TestFlight
 
-Builds, archives, and uploads the app to TestFlight. Triggered in two ways:
-
-- **Repository dispatch** from [scout](https://github.com/kasianov-mikhail/scout) — when scout's tests pass on `main`, it sends a `scout-updated` event. The workflow deletes `Package.resolved`, re-resolves to pick up the latest scout commit, creates a PR with the update, and enables auto-merge.
-- **Manual** via `workflow_dispatch`.
-
-If App Store Connect rejects the version, the workflow automatically bumps the minor version via PR. On success, it tags the build.
+Builds and uploads the app to TestFlight. Triggered when the Scout package updates or manually. Automatically bumps the version if App Store Connect rejects it.
 
 ## Debounce TestFlight
 
-Triggers on push to `main`. Waits 15 minutes before calling the TestFlight workflow. If another push arrives during the wait, the previous run is cancelled and the timer resets. This batches rapid changes into a single TestFlight build. Skips the build if the daily upload limit has been reached.
+Waits 15 minutes after the last push to main, then triggers TestFlight. Batches rapid changes into a single build.
 
 ## Auto Fix
 
-Currently disabled. Designed to run Claude Code via `claude-code-action` when Build Matrix fails, diagnose the issue, and create a fix PR automatically.
+Currently disabled. Runs Claude Code to diagnose and fix build failures automatically.

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -157,7 +157,7 @@ jobs:
           git commit -m "Bump version to $NEW_VERSION"
           git push -u origin "$BRANCH"
           gh pr create --title "Bump version to $NEW_VERSION" --body "Auto-bump: App Store rejected version $VERSION" --head "$BRANCH" --base main
-          gh pr merge "$BRANCH" --rebase --delete-branch
+          gh pr merge "$BRANCH" --auto --rebase --delete-branch
 
       - name: Tag build
         if: steps.upload.outputs.needs_bump != 'true'


### PR DESCRIPTION
- Add `--auto` to `gh pr merge` in the bump version step so it waits for required status checks
- Simplify WORKFLOWS.md — remove implementation details, keep only what each workflow does