### PR TITLE
Fix Resolve Conflicts workflow

### DIFF
--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -5,8 +5,29 @@ on:
     branches: [main]
 
 jobs:
+  find:
+    runs-on: ubuntu-latest
+    outputs:
+      prs: ${{ steps.check.outputs.prs }}
+    steps:
+      - name: Find conflicted PRs
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          sleep 30
+          PRS=$(gh pr list --repo ${{ github.repository }} --json number,mergeable --jq '[.[] | select(.mergeable == "CONFLICTING") | .number]')
+          echo "prs=$PRS" >> $GITHUB_OUTPUT
+
   resolve:
+    needs: find
+    if: needs.find.outputs.prs != '[]'
+    strategy:
+      matrix:
+        pr: ${{ fromJson(needs.find.outputs.prs) }}
     uses: kasianov-mikhail/.github/.github/workflows/resolve-conflicts.yml@main
+    with:
+      pr: ${{ matrix.pr }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
- Move find job to caller workflow since reusable workflows don't support multi-job with dynamic matrix
- Reusable workflow now takes a single PR number as input