### PR TITLE
Add permissions to caller workflows

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -5,6 +5,12 @@ on:
     workflows: [Build Matrix]
     types: [completed]
 
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  id-token: write
+
 jobs:
   fix:
     if: github.event.workflow_run.conclusion == 'failure'

--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  id-token: write
+
 jobs:
   find:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add explicit permissions to Auto Fix and Resolve Conflicts caller workflows
- Fixes startup_failure caused by reusable workflows requesting write permissions while callers defaulted to read-only