### PR TITLE
Show Package.resolved in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.resolved -linguist-generated


### PR DESCRIPTION
- Add .gitattributes to mark .resolved files as non-generated so GitHub renders them in diffs