### PR TITLE
Split dependency update from TestFlight to fix build spam

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,10 +3,15 @@
 Lints and builds the app on a matrix of simulators.
 Required to pass before merging.
 
+## 📦 Update Scout
+
+Triggers on repository_dispatch from scout.
+Updates Package.resolved to the latest scout commit and merges via PR.
+
 ## 🚀 TestFlight
 
 Builds and uploads the app to TestFlight.
-Triggered when the Scout package updates or manually.
+Triggered by Debounce TestFlight or manually.
 Bumps the version automatically if App Store Connect rejects it.
 
 ## ⏳ Debounce TestFlight

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,8 +1,6 @@
 name: TestFlight
 
 on:
-  repository_dispatch:
-    types: [scout-updated]
   workflow_dispatch:
 
 concurrency:
@@ -22,27 +20,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GH_PAT }}
-
-      - name: Update Scout dependency
-        if: github.event_name == 'repository_dispatch'
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          git config user.name "Mikhail Kasianov"
-          git config user.email "96941969+kasianov-mikhail@users.noreply.github.com"
-          rm ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
-          xcodebuild -resolvePackageDependencies -project ScoutIP.xcodeproj
-          if git diff --quiet; then
-            echo "No dependency changes"
-          else
-            BRANCH="auto/update-scout-$(date +%s)"
-            git checkout -b "$BRANCH"
-            git add ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
-            git commit -m "Update Scout dependency"
-            git push -u origin "$BRANCH"
-            gh pr create --title "Update Scout dependency" --body "Triggered by Scout update" --head "$BRANCH" --base main
-            gh pr merge "$BRANCH" --auto --rebase --delete-branch
-          fi
 
       - name: Set build number
         run: agvtool new-version -all $GITHUB_RUN_NUMBER
@@ -143,6 +120,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
+          git config user.name "Mikhail Kasianov"
+          git config user.email "96941969+kasianov-mikhail@users.noreply.github.com"
+
           VERSION=${{ steps.version.outputs.value }}
           MAJOR=$(echo $VERSION | cut -d. -f1)
           MINOR=$(echo $VERSION | cut -d. -f2)

--- a/.github/workflows/update-dependency.yml
+++ b/.github/workflows/update-dependency.yml
@@ -1,0 +1,35 @@
+name: Update Scout
+
+on:
+  repository_dispatch:
+    types: [scout-updated]
+
+jobs:
+  update:
+    runs-on: macos-26
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Update Scout dependency
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          git config user.name "Mikhail Kasianov"
+          git config user.email "96941969+kasianov-mikhail@users.noreply.github.com"
+          rm ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+          xcodebuild -resolvePackageDependencies -project ScoutIP.xcodeproj
+          if git diff --quiet; then
+            echo "No dependency changes"
+          else
+            BRANCH="auto/update-scout-$(date +%s)"
+            git checkout -b "$BRANCH"
+            git add ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+            git commit -m "Update Scout dependency"
+            git push -u origin "$BRANCH"
+            gh pr create --title "Update Scout dependency" --body "Triggered by Scout update" --head "$BRANCH" --base main
+            gh pr merge "$BRANCH" --auto --rebase --delete-branch
+          fi


### PR DESCRIPTION
- Extract dependency update into separate Update Scout workflow triggered by repository_dispatch
- Remove repository_dispatch trigger from TestFlight, keep only workflow_dispatch
- All TestFlight builds now go through debounce (15 min), eliminating duplicate builds
- Update workflow descriptions