### PR TITLE
Remove boilerplate comments from Persistence

### DIFF
--- a/ScoutIP/Persistence/Persistence.swift
+++ b/ScoutIP/Persistence/Persistence.swift
@@ -18,18 +18,6 @@ struct PersistenceController {
             if let error = error as NSError? {
                 let tracker = PersistenceTracker()
                 tracker.loadFailure(error: error)
-
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-
-                /*
-                 Typical reasons for an error here include:
-                 * The parent directory does not exist, cannot be created, or disallows writing.
-                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
-                 * The device is out of space.
-                 * The store could not be migrated to the current model version.
-                 Check the error message to determine what the actual problem was.
-                 */
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }
         })


### PR DESCRIPTION
- Remove Xcode-generated block comment and unused line comments
- Fixes swift-format NoBlockComments warning