### PR TITLE
Restore update-dependency and simplify hourly TestFlight

### DIFF
--- a/.github/workflows/hourly-testflight.yml
+++ b/.github/workflows/hourly-testflight.yml
@@ -6,36 +6,11 @@ on:
 
 jobs:
   check:
-    runs-on: macos-26
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.GH_PAT }}
-
-      - name: Update Scout dependency
-        id: dependency
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          git config user.name "Mikhail Kasianov"
-          git config user.email "96941969+kasianov-mikhail@users.noreply.github.com"
-          rm ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
-          xcodebuild -resolvePackageDependencies -project ScoutIP.xcodeproj
-          if ! git diff --quiet; then
-            BRANCH="auto/update-scout-$(date +%s)"
-            git checkout -b "$BRANCH"
-            git add ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
-            git commit -m "Update Scout dependency"
-            git push -u origin "$BRANCH"
-            gh pr create --title "Update Scout dependency" --body "Triggered by hourly check" --head "$BRANCH" --base main
-            gh pr merge "$BRANCH" --auto --rebase --delete-branch
-            echo "updated=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Check for new commits
-        if: steps.dependency.outputs.updated != 'true'
         id: commits
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
@@ -51,7 +26,7 @@ jobs:
           fi
 
       - name: Trigger TestFlight
-        if: steps.dependency.outputs.updated != 'true' && steps.commits.outputs.has_changes == 'true'
+        if: steps.commits.outputs.has_changes == 'true'
         run: gh workflow run testflight.yml --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/update-dependency.yml
+++ b/.github/workflows/update-dependency.yml
@@ -1,0 +1,35 @@
+name: Update Scout
+
+on:
+  repository_dispatch:
+    types: [scout-updated]
+
+jobs:
+  update:
+    runs-on: macos-26
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Update Scout dependency
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          git config user.name "Mikhail Kasianov"
+          git config user.email "96941969+kasianov-mikhail@users.noreply.github.com"
+          rm ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+          xcodebuild -resolvePackageDependencies -project ScoutIP.xcodeproj
+          if git diff --quiet; then
+            echo "No dependency changes"
+          else
+            BRANCH="auto/update-scout-$(date +%s)"
+            git checkout -b "$BRANCH"
+            git add ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+            git commit -m "Update Scout dependency"
+            git push -u origin "$BRANCH"
+            gh pr create --title "Update Scout dependency" --body "Triggered by Scout update" --head "$BRANCH" --base main
+            gh pr merge "$BRANCH" --auto --rebase --delete-branch
+          fi


### PR DESCRIPTION
- Restore update-dependency.yml triggered by scout notify dispatch
- Remove dependency update from hourly-testflight (now handled by update-dependency)
- Hourly workflow runs on ubuntu instead of macos