### PR TITLE
Enable Core Data persistent history tracking

### DIFF
--- a/ScoutIP/Persistence/Persistence.swift
+++ b/ScoutIP/Persistence/Persistence.swift
@@ -14,6 +14,9 @@ struct PersistenceController {
 
     init() {
         container = NSPersistentContainer(name: "ScoutIP")
+        container.persistentStoreDescriptions.first?.setOption(
+            true as NSNumber, forKey: NSPersistentHistoryTrackingKey
+        )
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
                 let tracker = PersistenceTracker()


### PR DESCRIPTION
Set NSPersistentHistoryTrackingKey to true on the container's persistentStoreDescription in PersistenceController.init(). This enables Core Data persistent history tracking so store-level changes can be observed/merged across contexts or background imports, improving synchronization and conflict handling.