### PR TITLE
Drop redundant License section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ A companion app for the [Scout](https://github.com/kasianov-mikhail/scout) packa
 - [Features](#features)
 - [Setup](#setup)
 - [App Store](#app-store)
-- [License](#license)
 
 ## Features
 
@@ -41,7 +40,3 @@ A companion app for the [Scout](https://github.com/kasianov-mikhail/scout) packa
 ## App Store
 
 [![Download on the App Store](https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg)](https://apps.apple.com/us/app/scout-ip/id6738300344)
-
-## License
-
-MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
- The MIT badge in the header already declares the license and links to LICENSE
- The LICENSE file at the repo root remains the authoritative artifact and is what GitHub uses for license detection
- Also removes the now-orphan License entry from the Table of Contents