### PR TITLE
Bump swift-log to 1.12.1 and swift-metrics to 2.11.0

### DIFF
--- a/ScoutIP.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ScoutIP.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
-        "version" : "1.12.0"
+        "revision" : "a012e0ad8a8a72de92b0e008c81a9b793f70e73a",
+        "version" : "1.12.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "c6593dac9d65f2517280d88c430dadffdf259737",
-        "version" : "2.10.0"
+        "revision" : "087e8074afa97040c3b870c8664fe5482fb87cc4",
+        "version" : "2.11.0"
       }
     }
   ],


### PR DESCRIPTION
- Update `swift-log` from 1.12.0 to 1.12.1 in `Package.resolved`
- Update `swift-metrics` from 2.10.0 to 2.11.0 in `Package.resolved`
- Pulls in upstream patch/minor releases of transitive dependencies via Scout