### PR TITLE
Track tab switches, history row opens, and favorite toggles

### DIFF
--- a/ScoutIP/App/AppSceneTracker.swift
+++ b/ScoutIP/App/AppSceneTracker.swift
@@ -33,6 +33,18 @@ struct AppSceneTracker {
         }
     }
 
+    func tabChanged(_ index: Int) {
+        let name: String =
+            switch index {
+            case 0: "info"
+            case 1: "history"
+            case 2: "debug"
+            default: "unknown"
+            }
+        Counter(label: "app.tab.\(name).count").increment()
+        appLogger.debug("TabChanged", metadata: ["tab": "\(name)"])
+    }
+
     func shortcutTriggered(_ shortcut: String?) {
         appLogger.trace("ShortcutsHandling", metadata: ["shortcut": "\(shortcut ?? "nil")"])
 

--- a/ScoutIP/App/ContentView.swift
+++ b/ScoutIP/App/ContentView.swift
@@ -68,6 +68,9 @@ struct ContentView: View {
                 handleActions()
             }
         }
+        .onChange(of: index) { _, newIndex in
+            sceneTracker.tabChanged(newIndex)
+        }
         .onShake {
             #if DEBUG
                 isScoutPresented = true

--- a/ScoutIP/Components/StarButton.swift
+++ b/ScoutIP/Components/StarButton.swift
@@ -11,6 +11,8 @@ struct StarButton: View {
     @ObservedObject var record: IPRecord
     @Environment(\.managedObjectContext) var viewContext
 
+    private let tracker = HistoryActionTracker()
+
     var body: some View {
         Button(action: toggle) {
             Image(systemName: record.isFavorite ? "star.fill" : "star")
@@ -27,5 +29,7 @@ struct StarButton: View {
             try viewContext.save()
         } catch {
         }
+
+        tracker.favoriteToggled(record.isFavorite)
     }
 }

--- a/ScoutIP/History/HistoryActionTracker.swift
+++ b/ScoutIP/History/HistoryActionTracker.swift
@@ -1,0 +1,24 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Logging
+import Metrics
+
+struct HistoryActionTracker {
+    private let appLogger = Logger(label: "ScoutIP.App")
+
+    func rowOpened() {
+        Counter(label: "history.row.opened.count").increment()
+        appLogger.debug("HistoryRowOpened")
+    }
+
+    func favoriteToggled(_ isFavorite: Bool) {
+        Counter(label: "history.favorite.toggled.count").increment()
+        appLogger.debug("HistoryFavoriteToggled", metadata: ["favorite": "\(isFavorite)"])
+    }
+}

--- a/ScoutIP/History/HistoryRow.swift
+++ b/ScoutIP/History/HistoryRow.swift
@@ -27,6 +27,8 @@ struct HistoryRow: View {
     @Environment(\.managedObjectContext) var viewContext
     @State private var isConfirmationPresented = false
 
+    private let tracker = HistoryActionTracker()
+
     var body: some View {
         NavigationLink(destination: HistoryIPList(records: item.records)) {
             HStack(spacing: 8) {
@@ -56,6 +58,9 @@ struct HistoryRow: View {
             }
             .tint(.yellow)
         }
+        .simultaneousGesture(TapGesture().onEnded {
+            tracker.rowOpened()
+        })
         .confirmationDialog("Are your sure?", isPresented: $isConfirmationPresented) {
             Button("Delete", role: .destructive) {
                 withAnimation {
@@ -82,10 +87,12 @@ struct HistoryRow: View {
     }
 
     func toggleFavorite() {
+        let newValue = !isFavorite
         for record in item.records {
-            record.isFavorite = !isFavorite
+            record.isFavorite = newValue
         }
         try? viewContext.save()
+        tracker.favoriteToggled(newValue)
     }
 
     var countryColor: Color {


### PR DESCRIPTION
Track tab switches, history row opens, and favorite toggles

Adds three frequently-fired background events to give Scout's timeline and aggregations a denser data set during normal use:

- `app.tab.<info|history|debug>.count` plus a `TabChanged` log entry, wired from `ContentView.onChange(of: index)`.
- `history.row.opened.count` / `HistoryRowOpened`, fired from a simultaneous tap gesture on each `HistoryRow`.
- `history.favorite.toggled.count` / `HistoryFavoriteToggled`, fired from both `HistoryRow.toggleFavorite()` and `StarButton.toggle()`.

The row/favorite events live on a new `HistoryActionTracker` to keep `HistoryDeleteTracker` focused on deletion outcomes.
