### PR TITLE
Track onboarding start and search funnel events

### DIFF
--- a/ScoutIP/App/AppDelegate.swift
+++ b/ScoutIP/App/AppDelegate.swift
@@ -19,6 +19,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         let tracker = AppLifecycleTracker()
         tracker.launch()
 
+        OnboardingTracker().startedIfFirstLaunch()
+
         Task {
             do {
                 try await Scout.setup(container: container)

--- a/ScoutIP/App/OnboardingTracker.swift
+++ b/ScoutIP/App/OnboardingTracker.swift
@@ -1,0 +1,25 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Logging
+import Metrics
+
+struct OnboardingTracker {
+    private let appLogger = Logger(label: "ScoutIP.App")
+    private let defaults = UserDefaults.standard
+    private let key = "OnboardingStartedFired"
+
+    func startedIfFirstLaunch() {
+        guard !defaults.bool(forKey: key) else {
+            return
+        }
+        defaults.set(true, forKey: key)
+        Counter(label: "onboarding.started.count").increment()
+        appLogger.info("OnboardingStarted")
+    }
+}

--- a/ScoutIP/Search/FunnelTracker.swift
+++ b/ScoutIP/Search/FunnelTracker.swift
@@ -1,0 +1,22 @@
+//
+// Copyright 2026 Mikhail Kasianov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import Foundation
+import Logging
+import Metrics
+
+struct FunnelTracker {
+    private let networkLogger = Logger(label: "ScoutIP.Network")
+
+    func searchPerformed(term: String) {
+        Counter(label: "search.performed.count").increment()
+        networkLogger.info(
+            "SearchPerformed",
+            metadata: ["term": "\(term.isEmpty ? "<own_ip>" : term)"]
+        )
+    }
+}

--- a/ScoutIP/Search/InfoProvider.swift
+++ b/ScoutIP/Search/InfoProvider.swift
@@ -40,6 +40,7 @@ private struct IPItem: Codable {
         let tracker = IPLookupTracker(source: ip.isEmpty ? .user : .manual)
         let start = DispatchTime.now()
         tracker.lookupStarted()
+        FunnelTracker().searchPerformed(term: ip)
 
         do {
             let data = try await URLSession.shared.data(from: url).0


### PR DESCRIPTION
Track onboarding start and search funnel events

Adds two funnel events so Scout has named events for top-of-funnel categorisation, beyond raw success/failure counters:

- `onboarding.started.count` plus an `OnboardingStarted` log entry, fired once per install from `AppDelegate.application(_:didFinishLaunchingWithOptions:)`. A `UserDefaults` flag guards subsequent launches.
- `search.performed.count` plus a `SearchPerformed` log entry carrying the queried term (or `<own_ip>` when the user looks up their own address), fired from `InfoProvider.ipObject()` alongside the existing `IPLookupTracker`.

Each event lives on its own struct (`OnboardingTracker`, `FunnelTracker`) so callers stay short.
