### PR TITLE
Extract signing setup into a composite action

### DIFF
--- a/.github/actions/setup-signing/action.yml
+++ b/.github/actions/setup-signing/action.yml
@@ -1,0 +1,68 @@
+name: Set up signing
+description: Imports signing certificates, the provisioning profile, and the App Store Connect API key into the runner.
+
+inputs:
+  build-certificate-base64:
+    description: Base64-encoded distribution certificate (.p12).
+    required: true
+  dev-certificate-base64:
+    description: Base64-encoded development certificate (.p12).
+    required: true
+  p12-password:
+    description: Password for the .p12 certificates.
+    required: true
+  keychain-password:
+    description: Password for the temporary signing keychain.
+    required: true
+  provisioning-profile-base64:
+    description: Base64-encoded provisioning profile.
+    required: true
+  api-key-base64:
+    description: Base64-encoded App Store Connect API key (.p8).
+    required: true
+  api-key-id:
+    description: App Store Connect API key ID.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install certificates and profile
+      shell: bash
+      env:
+        BUILD_CERTIFICATE_BASE64: ${{ inputs.build-certificate-base64 }}
+        DEV_CERTIFICATE_BASE64: ${{ inputs.dev-certificate-base64 }}
+        P12_PASSWORD: ${{ inputs.p12-password }}
+        KEYCHAIN_PASSWORD: ${{ inputs.keychain-password }}
+        PROVISIONING_PROFILE_BASE64: ${{ inputs.provisioning-profile-base64 }}
+      run: |
+        DIST_PATH=$RUNNER_TEMP/distribution.p12
+        DEV_PATH=$RUNNER_TEMP/development.p12
+        KEYCHAIN_PATH=$RUNNER_TEMP/signing.keychain-db
+        PP_PATH=$RUNNER_TEMP/profile.mobileprovision
+
+        echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $DIST_PATH
+        echo -n "$DEV_CERTIFICATE_BASE64" | base64 --decode -o $DEV_PATH
+        echo -n "$PROVISIONING_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+
+        security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+        security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+        security import $DIST_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+        security import $DEV_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+
+        security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+        security list-keychain -d user -s $KEYCHAIN_PATH
+
+        mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+        cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles/
+
+    - name: Write API key
+      shell: bash
+      env:
+        APP_STORE_CONNECT_KEY_BASE64: ${{ inputs.api-key-base64 }}
+        APP_STORE_CONNECT_KEY_ID: ${{ inputs.api-key-id }}
+      run: |
+        mkdir -p ~/private_keys
+        echo -n "$APP_STORE_CONNECT_KEY_BASE64" | base64 --decode -o ~/private_keys/AuthKey_$APP_STORE_CONNECT_KEY_ID.p8

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -55,42 +55,16 @@ jobs:
           echo "original=$REPO_VERSION" >> $GITHUB_OUTPUT
           echo "drift=$DRIFT" >> $GITHUB_OUTPUT
 
-      - name: Install certificates and profile
-        env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          DEV_CERTIFICATE_BASE64: ${{ secrets.DEV_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-          PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
-        run: |
-          DIST_PATH=$RUNNER_TEMP/distribution.p12
-          DEV_PATH=$RUNNER_TEMP/development.p12
-          KEYCHAIN_PATH=$RUNNER_TEMP/signing.keychain-db
-          PP_PATH=$RUNNER_TEMP/profile.mobileprovision
-
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $DIST_PATH
-          echo -n "$DEV_CERTIFICATE_BASE64" | base64 --decode -o $DEV_PATH
-          echo -n "$PROVISIONING_PROFILE_BASE64" | base64 --decode -o $PP_PATH
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-          security import $DIST_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security import $DEV_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-
-          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
-
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles/
-
-      - name: Write API key
-        run: |
-          mkdir -p ~/private_keys
-          echo -n "$APP_STORE_CONNECT_KEY_BASE64" | base64 --decode -o ~/private_keys/AuthKey_$APP_STORE_CONNECT_KEY_ID.p8
-        env:
-          APP_STORE_CONNECT_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
+      - name: Set up signing
+        uses: ./.github/actions/setup-signing
+        with:
+          build-certificate-base64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          dev-certificate-base64: ${{ secrets.DEV_CERTIFICATE_BASE64 }}
+          p12-password: ${{ secrets.P12_PASSWORD }}
+          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
+          provisioning-profile-base64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
+          api-key-base64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
+          api-key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
 
       - name: Archive
         run: |


### PR DESCRIPTION
The certificate, provisioning profile, and App Store Connect API key setup in the TestFlight workflow is generic signing boilerplate that doesn't depend on anything ScoutIP-specific. This moves those two steps into a reusable composite action at `.github/actions/setup-signing`, which takes the certificates, profile, and API key as inputs, so the workflow now invokes it with a single `uses` step. The behavior is unchanged — it's purely a refactor that keeps `testflight.yml` focused on the build-and-upload flow and makes the signing setup reusable should another workflow ever need it.
