### PR TITLE
Prevent overlapping Scout update runs

### DIFF
--- a/.github/workflows/update-dependency.yml
+++ b/.github/workflows/update-dependency.yml
@@ -4,6 +4,10 @@ on:
   repository_dispatch:
     types: [scout-updated]
 
+concurrency:
+  group: update-scout
+  cancel-in-progress: true
+
 jobs:
   update:
     runs-on: macos-26


### PR DESCRIPTION
Adds a `concurrency` group to the `Update Scout` workflow so that a new `scout-updated` dispatch cancels any run already in progress. Without it, two dispatches arriving close together each open their own auto-merge PR that touches the same `state.revision` line in `Package.resolved`; the first merges cleanly while the second gets stuck on a rebase conflict (or collapses to an empty no-op) and needs manual cleanup. Serialising the runs means only one update is ever in flight, so the PRs can no longer collide.