### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: ci
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds a Dependabot configuration that keeps the repository's GitHub Actions up to date. It checks daily, groups all action bumps into a single pull request to reduce noise, labels them with `dependencies` and `github-actions`, and prefixes commits with `ci`.

Only the `github-actions` ecosystem is configured. The Swift dependencies are managed inside the Xcode project rather than a `Package.swift` manifest, so Dependabot's `swift` ecosystem would not apply, and the Scout dependency is already kept current by the existing update workflow.