### PR TITLE
Adopt the Observation framework for IPInfo

### DIFF
--- a/ScoutIP/App/ContentView.swift
+++ b/ScoutIP/App/ContentView.swift
@@ -22,7 +22,7 @@ struct ContentView: View {
     @State private var index = 0
     @State private var state: UpdateState = .idle
     @State private var isScoutPresented = false
-    @StateObject private var ipInfo = IPInfo()
+    @State private var ipInfo = IPInfo()
 
     private var isBeta: Bool {
         #if DEBUG

--- a/ScoutIP/Search/IPInfo.swift
+++ b/ScoutIP/Search/IPInfo.swift
@@ -6,14 +6,15 @@
 // https://opensource.org/licenses/MIT.
 
 import CoreData
+import Observation
 import Scout
 import SwiftUI
 
-class IPInfo: ObservableObject {
+@Observable class IPInfo {
 
-    @Published var ip = ""
-    @Published var record: IPRecord?
-    @Published var errorText: String?
+    var ip = ""
+    var record: IPRecord?
+    var errorText: String?
 
     var allowSearch: Bool {
         ip.isEmpty || ip.isCompleteIP && record?.ip != ip

--- a/ScoutIP/Search/InfoView.swift
+++ b/ScoutIP/Search/InfoView.swift
@@ -11,7 +11,7 @@ struct InfoView: View {
     @Environment(\.managedObjectContext) var viewContext
 
     @Binding var state: UpdateState
-    @ObservedObject var ipInfo: IPInfo
+    @Bindable var ipInfo: IPInfo
     @State private var showCheckmark = false
     @State private var showConfetti = false
 

--- a/ScoutIP/Search/SearchView.swift
+++ b/ScoutIP/Search/SearchView.swift
@@ -11,7 +11,7 @@ struct SearchView: View {
     @Environment(\.managedObjectContext) var viewContext
 
     @Binding var state: UpdateState
-    @ObservedObject var ipInfo: IPInfo
+    let ipInfo: IPInfo
     @State private var text = ""
     @FocusState private var isFocused: Bool
 


### PR DESCRIPTION
Migrates `IPInfo` from an `ObservableObject` with `@Published` properties to an `@Observable` class so the views observe it through the modern Observation framework. `ContentView` now owns the instance with `@State`, `InfoView` declares it as `@Bindable` because it derives a binding for the error snackbar, and `SearchView` keeps it as a plain stored reference. Behaviour is unchanged.