### PR TITLE
Replace NavigationView with NavigationStack

### DIFF
--- a/ScoutIP/History/HistoryList.swift
+++ b/ScoutIP/History/HistoryList.swift
@@ -30,7 +30,7 @@ struct HistoryList: View {
     var records: FetchedResults<IPRecord>
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             List(selection: $selection) {
                 Picker("Filter", selection: $filter) {
                     ForEach(HistoryFilter.allCases) { filter in
@@ -116,7 +116,6 @@ struct HistoryList: View {
             .navigationTitle("History")
             .navigationBarTitleDisplayMode(.inline)
         }
-        .navigationViewStyle(.stack)
     }
 
     var items: [HistoryItem] {

--- a/ScoutIP/Search/InfoView.swift
+++ b/ScoutIP/Search/InfoView.swift
@@ -19,7 +19,7 @@ struct InfoView: View {
     var records: FetchedResults<IPRecord>
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             List {
                 Section("Search") {
                     SearchView(state: $state, ipInfo: ipInfo)
@@ -91,7 +91,6 @@ struct InfoView: View {
             .scrollDismissesKeyboard(.interactively)
             .navigationTitle("Info")
         }
-        .navigationViewStyle(.stack)
         .confetti(isPresented: showConfetti)
         .snackbar(text: $ipInfo.errorText)
         .onChange(of: records.count) {


### PR DESCRIPTION
Replaces the deprecated `NavigationView` with `NavigationStack` in `InfoView` and `HistoryList`. Both screens already forced the stack style, so the now-redundant `.navigationViewStyle(.stack)` modifier is removed as well.