### PR TITLE
Replace DispatchQueue delays with structured concurrency

### DIFF
--- a/ScoutIP/Components/Snackbar.swift
+++ b/ScoutIP/Components/Snackbar.swift
@@ -45,10 +45,9 @@ struct Snackbar: View {
                     .onTapGesture {
                         self.text = nil
                     }
-                    .onAppear {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
-                            self.text = nil
-                        }
+                    .task {
+                        try? await Task.sleep(for: .seconds(4))
+                        self.text = nil
                     }
             }
         }

--- a/ScoutIP/Search/InfoView.swift
+++ b/ScoutIP/Search/InfoView.swift
@@ -82,7 +82,8 @@ struct InfoView: View {
                 state = .idle
                 if ipInfo.errorText == nil {
                     showCheckmark = true
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                    Task {
+                        try? await Task.sleep(for: .seconds(1.5))
                         showCheckmark = false
                     }
                 }
@@ -97,7 +98,8 @@ struct InfoView: View {
         .onChange(of: records.count) {
             if records.count > 0 && records.count % 100 == 0 {
                 showConfetti = true
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                Task {
+                    try? await Task.sleep(for: .seconds(2))
                     showConfetti = false
                 }
             }


### PR DESCRIPTION
Replaces the `DispatchQueue.main.asyncAfter` timers with `Task.sleep(for:)`. In `InfoView` the checkmark and confetti auto-dismiss now run inside a child `Task`, and in `Snackbar` the four-second auto-dismiss moves from `.onAppear` to a `.task` that is cancelled automatically when the snackbar disappears.