### PR TITLE
Remove stale debug-screen entries from string catalog

### DIFF
--- a/ScoutIP/Resources/Localizable.xcstrings
+++ b/ScoutIP/Resources/Localizable.xcstrings
@@ -495,9 +495,6 @@
         }
       }
     },
-    "Increment counter" : {
-
-    },
     "Info" : {
       "localizations" : {
         "de" : {
@@ -634,30 +631,6 @@
           }
         }
       }
-    },
-    "Log 10 events" : {
-
-    },
-    "Log 100 + 100 metrics" : {
-
-    },
-    "Log 1000 events" : {
-
-    },
-    "Log error" : {
-
-    },
-    "Log warning" : {
-
-    },
-    "Logged: %lld events" : {
-
-    },
-    "Logging" : {
-
-    },
-    "Metrics" : {
-
     },
     "My IP" : {
       "localizations" : {
@@ -870,15 +843,6 @@
         }
       }
     },
-    "Rapid fire (10 per second for 30s)" : {
-
-    },
-    "Record timer (1s)" : {
-
-    },
-    "Recorded: %lld metrics" : {
-
-    },
     "Region" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -913,9 +877,6 @@
           }
         }
       }
-    },
-    "Running..." : {
-
     },
     "Save" : {
       "localizations" : {
@@ -1057,9 +1018,6 @@
           }
         }
       }
-    },
-    "Stress Test" : {
-
     },
     "Timezone" : {
       "extractionState" : "stale",


### PR DESCRIPTION
Cleans up `Localizable.xcstrings` by removing leftover entries that no longer correspond to any code — untranslated strings from the old debug stress-test section such as `Log 10 events`, `Stress Test`, and `Rapid fire`. These had no localizations and were only adding noise to the string catalog.