### PR TITLE
Close superseded auto-update PRs in update-dependency workflow

### DIFF
--- a/.github/workflows/update-dependency.yml
+++ b/.github/workflows/update-dependency.yml
@@ -37,4 +37,7 @@ jobs:
             git push -u origin "$BRANCH"
             gh pr create --title "Update Scout dependency to $SHA" --body "Triggered by Scout update" --head "$BRANCH" --base main
             gh pr merge "$BRANCH" --auto --rebase --delete-branch
+            gh pr list --state open --json number,headRefName \
+              --jq '.[] | select(.headRefName | startswith("auto/update-scout-")) | select(.headRefName != "'"$BRANCH"'") | .number' \
+              | xargs -I{} gh pr close {} --comment "Superseded by Scout update to $SHA" --delete-branch
           fi


### PR DESCRIPTION
When Scout updates arrive in quick succession, the `Update Scout` workflow creates a separate PR for each one, all editing the same line of `Package.resolved`. As soon as one merges, the rest become conflicting and pile up as stale open PRs. Now, after creating a new update PR, the workflow closes any other open `auto/update-scout-*` PRs and deletes their branches, since each new update supersedes the previous ones.