### PR TITLE
Add app size report workflow

### DIFF
--- a/.github/workflows/app-size.yml
+++ b/.github/workflows/app-size.yml
@@ -1,0 +1,98 @@
+name: App Size
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  report:
+    runs-on: macos-26
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Restore base size
+        id: base-cache
+        uses: actions/cache@v4
+        with:
+          path: base-size.txt
+          key: app-size-${{ github.event.pull_request.base.sha }}
+
+      - name: Measure base
+        if: steps.base-cache.outputs.cache-hit != 'true'
+        run: |
+          set -o pipefail
+          git fetch origin ${{ github.event.pull_request.base.sha }}
+          git checkout ${{ github.event.pull_request.base.sha }}
+          xcodebuild build \
+            IPINFO_KEY=${{ secrets.IPINFO_KEY }} \
+            CODE_SIGNING_ALLOWED=NO \
+            -project ScoutIP.xcodeproj \
+            -scheme ScoutIP \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -derivedDataPath $RUNNER_TEMP/base \
+            | xcbeautify
+          APP=$RUNNER_TEMP/base/Build/Products/Release-iphoneos/ScoutIP.app
+          ditto -c -k --keepParent "$APP" $RUNNER_TEMP/base.zip
+          echo "$(($(du -sk "$APP" | cut -f1) * 1024)) $(stat -f%z $RUNNER_TEMP/base.zip)" > base-size.txt
+          git checkout ${{ github.sha }}
+
+      - name: Measure PR
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            IPINFO_KEY=${{ secrets.IPINFO_KEY }} \
+            CODE_SIGNING_ALLOWED=NO \
+            -project ScoutIP.xcodeproj \
+            -scheme ScoutIP \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -derivedDataPath $RUNNER_TEMP/head \
+            | xcbeautify
+          APP=$RUNNER_TEMP/head/Build/Products/Release-iphoneos/ScoutIP.app
+          ditto -c -k --keepParent "$APP" $RUNNER_TEMP/head.zip
+          echo "$(($(du -sk "$APP" | cut -f1) * 1024)) $(stat -f%z $RUNNER_TEMP/head.zip)" > head-size.txt
+
+      - name: Comment report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          read BASE_RAW BASE_ZIP < base-size.txt
+          read HEAD_RAW HEAD_ZIP < head-size.txt
+
+          row() {
+            awk -v base=$2 -v head=$3 'BEGIN {
+              d = head - base
+              printf "| %s | %.2f MB | %.2f MB | %+.2f MB (%+.1f%%) |", \
+                "'"$1"'", base/1048576, head/1048576, d/1048576, base ? d*100/base : 0
+            }'
+          }
+
+          BODY="<!-- app-size-report -->
+          ## 📦 App Size
+
+          | | Base | PR | Δ |
+          |---|---|---|---|
+          $(row "Uncompressed" $BASE_RAW $HEAD_RAW)
+          $(row "Compressed (zip)" $BASE_ZIP $HEAD_ZIP)
+
+          Release build for \`generic/platform=iOS\`, unsigned. Base: \`${{ github.event.pull_request.base.sha }}\`"
+
+          PR=${{ github.event.pull_request.number }}
+          COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/$PR/comments \
+            --jq '[.[] | select(.body | contains("<!-- app-size-report -->"))][0].id // empty')
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api -X PATCH repos/${{ github.repository }}/issues/comments/$COMMENT_ID -f body="$BODY" > /dev/null
+          else
+            gh api repos/${{ github.repository }}/issues/$PR/comments -f body="$BODY" > /dev/null
+          fi


### PR DESCRIPTION
Adds an `App Size` workflow that reports how each pull request affects the size of the app. It builds an unsigned Release `.app` for the PR and for the base commit, then posts a sticky comment with the uncompressed and zip-compressed sizes and their delta. The base measurement is cached by commit SHA, so repeated pushes to a PR only rebuild the PR side.