### PR TITLE
Ignore local build output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ fastlane/test_output
 
 # Secrets
 Secrets.xcconfig
+
+# Local build output
+build/


### PR DESCRIPTION
Adds the `build/` directory to `.gitignore` so local build artifacts no longer show up as untracked files, and restores the missing trailing newline at the end of the file.