### PR TITLE
Handle bogon responses from ipinfo.io

### DIFF
--- a/ScoutIP/Search/InfoProvider.swift
+++ b/ScoutIP/Search/InfoProvider.swift
@@ -16,6 +16,19 @@ struct IPError: LocalizedError {
     }
 }
 
+struct BogonError: LocalizedError {
+    let ip: String
+
+    var errorDescription: String? {
+        "\(ip) is a private or reserved IP address"
+    }
+}
+
+private struct BogonItem: Codable {
+    let ip: String
+    let bogon: Bool
+}
+
 private struct IPItem: Codable {
     let ip: String
     let city: String?
@@ -44,6 +57,9 @@ private struct IPItem: Codable {
 
         do {
             let data = try await URLSession.shared.data(from: url).0
+            if let bogon = try? JSONDecoder().decode(BogonItem.self, from: data), bogon.bogon {
+                throw BogonError(ip: bogon.ip)
+            }
             let item = try JSONDecoder().decode(IPItem.self, from: data)
             tracker.success(duration: start)
             return IPObject(item: item, context: context)


### PR DESCRIPTION
Looking up a private or reserved address crashed the lookup with a raw `keyNotFound("region")` decoding error, because ipinfo.io returns only `ip` and `bogon` fields for such addresses and `IPItem` expects the full geo payload. The response is now first tried against a new `BogonItem` model, and when it matches, the lookup fails with a new `BogonError` that tells the user the address is private or reserved instead of showing the decoder dump.