### PR TITLE
Remove test marker from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,3 @@ A companion app for the [Scout](https://github.com/kasianov-mikhail/scout) packa
 ## App Store
 
 [![Download on the App Store](https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg)](https://apps.apple.com/us/app/scout-ip/id6738300344)
-
-<!-- test: auto-merge toggle check -->


### PR DESCRIPTION
Removes the temporary marker comment that landed on `main` when the auto-merge test PR was merged. This PR can also be used to verify the auto-merge toggle in the app.