### PR TITLE
Disable CloudKit mirroring so the SwiftData store can load

### DIFF
--- a/ScoutIP.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ScoutIP.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "44d1b9ba7f2d6b67a9ddf576ef2a3ee25a9adac30ca33f7570463850a2bf16ec",
+  "originHash" : "8146b52b686ef86b233426688ef013d889a0bca91c7c717e1e3488ea17903620",
   "pins" : [
+    {
+      "identity" : "scout",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kasianov-mikhail/scout",
+      "state" : {
+        "branch" : "main",
+        "revision" : "bdc5aabc4ea989fc7604bb1a45c5c75025573289"
+      }
+    },
     {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",

--- a/ScoutIP/Persistence/Persistence.swift
+++ b/ScoutIP/Persistence/Persistence.swift
@@ -21,8 +21,13 @@ struct PersistenceController {
             try FileManager.default.createDirectory(
                 at: .applicationSupportDirectory, withIntermediateDirectories: true
             )
+            // The app carries a CloudKit entitlement for Scout logging, which
+            // makes the default .automatic mirroring claim that container and
+            // refuse to load the store (the schema is not CloudKit-compatible).
+            // The store has never synced, so mirroring stays off.
             let configuration = ModelConfiguration(
-                url: URL.applicationSupportDirectory.appendingPathComponent("ScoutIP.sqlite")
+                url: URL.applicationSupportDirectory.appendingPathComponent("ScoutIP.sqlite"),
+                cloudKitDatabase: .none
             )
             container = try ModelContainer(
                 for: IPRecord.self, IPObject.self,


### PR DESCRIPTION
On `main` the SwiftData store fails to load: the app carries a CloudKit entitlement for Scout logging, so the default `.automatic` value of `cloudKitDatabase` tries to attach CloudKit mirroring, and mirroring's schema validation rejects the non-optional `IPRecord.object` relationship. `ModelContainer` does not throw in this situation — the app launches with no working persistence, new lookups are never saved, and existing users' history never appears. Setting `cloudKitDatabase: .none` matches the previous `NSPersistentContainer` setup, which never synced this store to CloudKit.

Verified in the simulator: on current `main` a fresh install creates no store file and logs `CloudKit integration requires that all relationships be optional`; with this change the store is created, a data store seeded by the pre-migration Core Data build is adopted in place with all records intact, and fetches, inserts, edits, and cascade deletes against the adopted store all work.

This PR originally contained an independent SwiftData migration written before #258 landed; it has been rebased to keep only this fix on top of `main`.