### PR TITLE
Fix auto-merge in workflows: squash method and conflict handling

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -150,7 +150,17 @@ jobs:
           git commit -m "Bump version to $NEW_VERSION"
           git push -u origin "$BRANCH"
           gh pr create --title "Bump version to $NEW_VERSION" --body "$BODY" --head "$BRANCH" --base main
-          gh pr merge "$BRANCH" --auto --squash --delete-branch
+          # Mergeability is computed asynchronously, so poll until GitHub reports it
+          for _ in {1..10}; do
+            MERGEABLE=$(gh pr view "$BRANCH" --json mergeable --jq '.mergeable')
+            [ "$MERGEABLE" != "UNKNOWN" ] && break
+            sleep 3
+          done
+          if [ "$MERGEABLE" = "CONFLICTING" ]; then
+            gh pr close "$BRANCH" --comment "Closed due to merge conflicts" --delete-branch
+          else
+            gh pr merge "$BRANCH" --auto --squash --delete-branch
+          fi
 
       - name: Tag build
         if: steps.upload.outputs.needs_bump != 'true'

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -150,7 +150,7 @@ jobs:
           git commit -m "Bump version to $NEW_VERSION"
           git push -u origin "$BRANCH"
           gh pr create --title "Bump version to $NEW_VERSION" --body "$BODY" --head "$BRANCH" --base main
-          gh pr merge "$BRANCH" --auto --rebase --delete-branch
+          gh pr merge "$BRANCH" --auto --squash --delete-branch
 
       - name: Tag build
         if: steps.upload.outputs.needs_bump != 'true'

--- a/.github/workflows/update-dependency.yml
+++ b/.github/workflows/update-dependency.yml
@@ -36,7 +36,7 @@ jobs:
             git commit -m "Update Scout dependency to $SHA"
             git push -u origin "$BRANCH"
             gh pr create --title "Update Scout dependency to $SHA" --body "Triggered by Scout update" --head "$BRANCH" --base main
-            gh pr merge "$BRANCH" --auto --rebase --delete-branch
+            gh pr merge "$BRANCH" --auto --squash --delete-branch
             gh pr list --state open --json number,headRefName \
               --jq '.[] | select(.headRefName | startswith("auto/update-scout-")) | select(.headRefName != "'"$BRANCH"'") | .number' \
               | xargs -I{} gh pr close {} --comment "Superseded by Scout update to $SHA" --delete-branch

--- a/.github/workflows/update-dependency.yml
+++ b/.github/workflows/update-dependency.yml
@@ -36,7 +36,17 @@ jobs:
             git commit -m "Update Scout dependency to $SHA"
             git push -u origin "$BRANCH"
             gh pr create --title "Update Scout dependency to $SHA" --body "Triggered by Scout update" --head "$BRANCH" --base main
-            gh pr merge "$BRANCH" --auto --squash --delete-branch
+            # Mergeability is computed asynchronously, so poll until GitHub reports it
+            for _ in {1..10}; do
+              MERGEABLE=$(gh pr view "$BRANCH" --json mergeable --jq '.mergeable')
+              [ "$MERGEABLE" != "UNKNOWN" ] && break
+              sleep 3
+            done
+            if [ "$MERGEABLE" = "CONFLICTING" ]; then
+              gh pr close "$BRANCH" --comment "Closed due to merge conflicts" --delete-branch
+            else
+              gh pr merge "$BRANCH" --auto --squash --delete-branch
+            fi
             gh pr list --state open --json number,headRefName \
               --jq '.[] | select(.headRefName | startswith("auto/update-scout-")) | select(.headRefName != "'"$BRANCH"'") | .number' \
               | xargs -I{} gh pr close {} --comment "Superseded by Scout update to $SHA" --delete-branch


### PR DESCRIPTION
The `Update Scout` and `TestFlight` workflows enabled auto-merge on their PRs with the rebase method, which the repository no longer allows, so the `gh pr merge --auto` step failed and auto-merge was never enabled. Both workflows now use `--squash` instead, matching the repository merge settings. Additionally, after creating a PR they now wait for GitHub to compute mergeability and close the PR if it has merge conflicts, instead of leaving a stuck auto-merge behind.