### PR TITLE
Stop posting app size report as a PR comment

### DIFF
--- a/.github/workflows/app-size.yml
+++ b/.github/workflows/app-size.yml
@@ -9,7 +9,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   report:
@@ -62,9 +61,7 @@ jobs:
           ditto -c -k --keepParent "$APP" $RUNNER_TEMP/head.zip
           echo "$(($(du -sk "$APP" | cut -f1) * 1024)) $(stat -f%z $RUNNER_TEMP/head.zip)" > head-size.txt
 
-      - name: Comment report
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Report
         run: |
           read BASE_RAW BASE_ZIP < base-size.txt
           read HEAD_RAW HEAD_ZIP < head-size.txt
@@ -77,8 +74,7 @@ jobs:
             }'
           }
 
-          BODY="<!-- app-size-report -->
-          ## 📦 App Size
+          BODY="## 📦 App Size
 
           | | Base | PR | Δ |
           |---|---|---|---|
@@ -87,12 +83,4 @@ jobs:
 
           Release build for \`generic/platform=iOS\`, unsigned. Base: \`${{ github.event.pull_request.base.sha }}\`"
 
-          PR=${{ github.event.pull_request.number }}
-          COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/$PR/comments \
-            --jq '[.[] | select(.body | contains("<!-- app-size-report -->"))][0].id // empty')
-
-          if [ -n "$COMMENT_ID" ]; then
-            gh api -X PATCH repos/${{ github.repository }}/issues/comments/$COMMENT_ID -f body="$BODY" > /dev/null
-          else
-            gh api repos/${{ github.repository }}/issues/$PR/comments -f body="$BODY" > /dev/null
-          fi
+          echo "$BODY" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The `App Size` workflow used to publish its report as a comment on every pull request, which added noise to PR threads. The workflow still builds and measures the app, but the report now goes to the job summary in Actions instead of a PR comment. The `pull-requests: write` permission is no longer needed and has been removed.