### PR TITLE
Enable SwiftData CloudKit sync

### DIFF
--- a/ScoutIP/History/HistoryIPList.swift
+++ b/ScoutIP/History/HistoryIPList.swift
@@ -40,8 +40,8 @@ struct HistoryIPList: View {
             }
         }
         .toolbar {
-            if let record = records.first {
-                ShareLink(item: record.object.shareDescription)
+            if let object = records.first?.object {
+                ShareLink(item: object.shareDescription)
                     .simultaneousGesture(TapGesture().onEnded { ShareTracker().shared() })
             }
             StarListButton(isStarred: $isStarred)

--- a/ScoutIP/History/HistoryInfoView.swift
+++ b/ScoutIP/History/HistoryInfoView.swift
@@ -12,19 +12,22 @@ struct HistoryInfoView: View {
 
     var body: some View {
         List {
-            Section("Info") {
-                ForEach(record.object.pairs, id: \.key) { pair in
-                    HStack {
-                        Text(pair.key)
-                        Spacer()
-                        Text(pair.value).font(.system(size: 16)).multilineTextAlignment(.trailing)
+            if let object = record.object {
+                Section("Info") {
+                    ForEach(object.pairs, id: \.key) { pair in
+                        HStack {
+                            Text(pair.key)
+                            Spacer()
+                            Text(pair.value).font(.system(size: 16)).multilineTextAlignment(
+                                .trailing)
+                        }
+                        .textSelection(.enabled)
                     }
-                    .textSelection(.enabled)
                 }
-            }
-            Section("Location") {
-                if let location = Location(string: record.object.loc) {
-                    MapView(location: location)
+                Section("Location") {
+                    if let location = Location(string: object.loc) {
+                        MapView(location: location)
+                    }
                 }
             }
             Section("Notes") {
@@ -32,8 +35,10 @@ struct HistoryInfoView: View {
             }
         }
         .toolbar {
-            ShareLink(item: record.object.shareDescription)
-                .simultaneousGesture(TapGesture().onEnded { ShareTracker().shared() })
+            if let object = record.object {
+                ShareLink(item: object.shareDescription)
+                    .simultaneousGesture(TapGesture().onEnded { ShareTracker().shared() })
+            }
             StarButton(record: record)
         }
         .scrollDismissesKeyboard(.interactively)

--- a/ScoutIP/History/HistoryRow.swift
+++ b/ScoutIP/History/HistoryRow.swift
@@ -96,7 +96,7 @@ struct HistoryRow: View {
     }
 
     var countryColor: Color {
-        let country = item.records.first?.object.country ?? ""
+        let country = item.records.first?.object?.country ?? ""
         let hash = abs(country.hashValue)
         let colors: [Color] = [
             .blue, .green, .orange, .purple, .pink, .teal, .indigo, .mint, .cyan, .brown,

--- a/ScoutIP/Persistence/IPRecord.swift
+++ b/ScoutIP/Persistence/IPRecord.swift
@@ -24,8 +24,11 @@ import SwiftData
     var isHidden = false
     var notes = ""
 
+    // Optional as required by CloudKit mirroring; in practice the object
+    // is only nil while a record synced from another device is partially
+    // downloaded.
     @Relationship(deleteRule: .cascade)
-    var object: IPObject
+    var object: IPObject?
 
     init(date: Date, isUser: Bool, object: IPObject) {
         self.date = date
@@ -34,7 +37,7 @@ import SwiftData
     }
 
     var ip: String {
-        object.ip
+        object?.ip ?? ""
     }
 
     var dateText: String {

--- a/ScoutIP/Persistence/Persistence.swift
+++ b/ScoutIP/Persistence/Persistence.swift
@@ -21,13 +21,11 @@ struct PersistenceController {
             try FileManager.default.createDirectory(
                 at: .applicationSupportDirectory, withIntermediateDirectories: true
             )
-            // The app carries a CloudKit entitlement for Scout logging, which
-            // makes the default .automatic mirroring claim that container and
-            // refuse to load the store (the schema is not CloudKit-compatible).
-            // The store has never synced, so mirroring stays off.
+            // The container is named explicitly because the entitlements also
+            // list the Scout logging container, which .automatic would pick up.
             let configuration = ModelConfiguration(
                 url: URL.applicationSupportDirectory.appendingPathComponent("ScoutIP.sqlite"),
-                cloudKitDatabase: .none
+                cloudKitDatabase: .private("iCloud.com.kasianov.ScoutIP")
             )
             container = try ModelContainer(
                 for: IPRecord.self, IPObject.self,

--- a/ScoutIP/Resources/Info.plist
+++ b/ScoutIP/Resources/Info.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>IPINFO_KEY</key>
 	<string>$(IPINFO_KEY)</string>
 </dict>

--- a/ScoutIP/Resources/ScoutIP.entitlements
+++ b/ScoutIP/Resources/ScoutIP.entitlements
@@ -7,6 +7,7 @@
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.Logging.Scout.0001</string>
+		<string>iCloud.com.kasianov.ScoutIP</string>
 	</array>
 	<key>com.apple.developer.icloud-services</key>
 	<array>

--- a/ScoutIP/Search/InfoView.swift
+++ b/ScoutIP/Search/InfoView.swift
@@ -28,9 +28,9 @@ struct InfoView: View {
 
                 if state == .load {
                     SkeletonView()
-                } else if let record = ipInfo.activeRecord {
+                } else if let record = ipInfo.activeRecord, let object = record.object {
                     Section("Info") {
-                        ForEach(record.object.pairs, id: \.key) { pair in
+                        ForEach(object.pairs, id: \.key) { pair in
                             HStack {
                                 Text(pair.key)
                                 Spacer()
@@ -49,7 +49,7 @@ struct InfoView: View {
                         }
                     }
                     Section("Location") {
-                        if let location = Location(string: record.object.loc) {
+                        if let location = Location(string: object.loc) {
                             MapView(location: location)
                         }
                     }
@@ -69,8 +69,8 @@ struct InfoView: View {
             }
             .toolbar {
                 ToolbarItemGroup(placement: .topBarTrailing) {
-                    if let record = ipInfo.activeRecord {
-                        ShareLink(item: record.object.shareDescription)
+                    if let record = ipInfo.activeRecord, let object = record.object {
+                        ShareLink(item: object.shareDescription)
                             .simultaneousGesture(TapGesture().onEnded { ShareTracker().shared() })
                         StarButton(record: record)
                     }


### PR DESCRIPTION
The SwiftData store is now mirrored to iCloud, so search history syncs across the user's devices. Mirroring goes to a dedicated private container, `iCloud.com.kasianov.ScoutIP`, named explicitly in `Persistence.swift` so the existing Scout logging container is left alone. To satisfy CloudKit's schema rules, the `IPRecord.object` relationship became optional, and the views now unwrap it with `if let`; the `remote-notification` background mode lets changes from other devices arrive via push.

Two manual steps remain before sync works end to end: the new container has to be registered in the developer account (Xcode does this automatically with automatic signing), and once a debug build has created the Development schema, it needs to be deployed to Production in the CloudKit Console.