### PR TITLE
Remove country color indicator from history rows

### DIFF
--- a/ScoutIP/History/HistoryRow.swift
+++ b/ScoutIP/History/HistoryRow.swift
@@ -32,9 +32,6 @@ struct HistoryRow: View {
     var body: some View {
         NavigationLink(destination: HistoryIPList(records: item.records)) {
             HStack(spacing: 8) {
-                Circle()
-                    .fill(countryColor)
-                    .frame(width: 8, height: 8)
                 Text(title).font(.system(size: 17))
                 if item.records.contains(where: { !$0.notes.isEmpty }) {
                     Circle().foregroundColor(.yellow).frame(width: 6, height: 6)
@@ -93,15 +90,6 @@ struct HistoryRow: View {
         }
         try? modelContext.save()
         tracker.favoriteToggled(newValue)
-    }
-
-    var countryColor: Color {
-        let country = item.records.first?.object.country ?? ""
-        let hash = abs(country.hashValue)
-        let colors: [Color] = [
-            .blue, .green, .orange, .purple, .pink, .teal, .indigo, .mint, .cyan, .brown,
-        ]
-        return colors[hash % colors.count]
     }
 
     func hide() {


### PR DESCRIPTION
Removes the `countryColor` functionality from the app. History rows previously showed a small colored dot next to each IP address, with the color derived from a hash of the record's country. The dot and the `countryColor` property in `HistoryRow` are gone, leaving the row to lead with the IP address itself.