### PR TITLE
Sync analytics to the self-hosted Scout server alongside CloudKit

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -71,6 +71,8 @@ jobs:
           set -o pipefail
           xcodebuild archive \
             IPINFO_KEY=${{ secrets.IPINFO_KEY }} \
+            SCOUT_IP=${{ secrets.SCOUT_IP }} \
+            SCOUT_API_KEYS=${{ secrets.SCOUT_API_KEYS }} \
             -project ScoutIP.xcodeproj \
             -scheme ScoutIP \
             -archivePath $RUNNER_TEMP/ScoutIP.xcarchive \

--- a/ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/kasianov-mikhail/scout",
       "state" : {
         "branch" : "main",
-        "revision" : "fe89df0c6e0b16767b78f0095124322912da9dec"
+        "revision" : "6bfb93b1431d13108804d612e0dfeb1219c699d5"
       }
     },
     {

--- a/ScoutIP/App/AppDelegate.swift
+++ b/ScoutIP/App/AppDelegate.swift
@@ -11,6 +11,23 @@ import UIKit
 
 let container = CKContainer(identifier: "iCloud.Logging.Scout.0001")
 
+/// CloudKit plus the self-hosted Scout server when its address is baked into
+/// the build (the `SCOUT_IP` and `SCOUT_API_KEYS` build settings).
+///
+var backends: [Backend] {
+    var backends: [Backend] = [.cloudKit(container)]
+
+    if let address = Bundle.main.infoDictionary?["SCOUT_IP"] as? String,
+        !address.isEmpty,
+        let url = URL(string: address)
+    {
+        let apiKey = Bundle.main.infoDictionary?["SCOUT_API_KEYS"] as? String
+        backends.append(.server(url: url, apiKey: apiKey?.isEmpty == false ? apiKey : nil))
+    }
+
+    return backends
+}
+
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(
         _ application: UIApplication,
@@ -23,7 +40,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
         Task {
             do {
-                try await Scout.setup(container: container)
+                try await Scout.setup(backends: backends)
             } catch {
                 tracker.scoutSetupFailure(error: error)
             }

--- a/ScoutIP/Resources/Info.plist
+++ b/ScoutIP/Resources/Info.plist
@@ -10,5 +10,9 @@
 	</array>
 	<key>IPINFO_KEY</key>
 	<string>$(IPINFO_KEY)</string>
+	<key>SCOUT_IP</key>
+	<string>$(SCOUT_IP)</string>
+	<key>SCOUT_API_KEYS</key>
+	<string>$(SCOUT_API_KEYS)</string>
 </dict>
 </plist>

--- a/Secrets.xcconfig.template
+++ b/Secrets.xcconfig.template
@@ -2,3 +2,8 @@
 // Secrets.xcconfig is git-ignored and should not be committed.
 
 IPINFO_KEY = YOUR_KEY_HERE
+
+// The self-hosted Scout server. xcconfig treats "//" as a comment, so the
+// URL scheme needs the $() escape. Leave empty to sync to CloudKit only.
+SCOUT_IP = http:/$()/138.124.123.246:8080
+SCOUT_API_KEYS = YOUR_KEY_HERE


### PR DESCRIPTION
The app now builds its backend list at startup: the usual CloudKit `container` plus, when the `SCOUT_IP` build setting is baked into the bundle, a `.server` backend pointing at the self-hosted scout-server with the key from `SCOUT_API_KEYS`. The Scout dependency is bumped to the revision that introduced multi-backend `setup`, the TestFlight workflow passes both values from repository secrets, and `Secrets.xcconfig.template` documents them for local builds.