### PR TITLE
Export TestFlight build with automatic signing

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -90,6 +90,10 @@ jobs:
             -archivePath $RUNNER_TEMP/ScoutIP.xcarchive \
             -exportOptionsPlist ExportOptions.plist \
             -exportPath $RUNNER_TEMP/export \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/private_keys/AuthKey_$APP_STORE_CONNECT_KEY_ID.p8 \
+            -authenticationKeyID $APP_STORE_CONNECT_KEY_ID \
+            -authenticationKeyIssuerID $APP_STORE_CONNECT_ISSUER_ID \
             | xcbeautify
 
       - name: Upload to TestFlight

--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -3,18 +3,11 @@
 <plist version="1.0">
 <dict>
     <key>method</key>
-    <string>app-store</string>
+    <string>app-store-connect</string>
     <key>teamID</key>
     <string>CGU22629ZT</string>
     <key>signingStyle</key>
-    <string>manual</string>
-    <key>provisioningProfiles</key>
-    <dict>
-        <key>com.kasianov.ScoutIP</key>
-        <string>ScoutIP App Store</string>
-    </dict>
-    <key>signingCertificate</key>
-    <string>Apple Distribution</string>
+    <string>automatic</string>
     <key>uploadSymbols</key>
     <true/>
 </dict>


### PR DESCRIPTION
The TestFlight deploy was failing at the `Export archive` step because the manually exported "ScoutIP App Store" provisioning profile baked into the `PROVISIONING_PROFILE_BASE64` secret had gone stale. It was generated before #296 added the `iCloud.com.kasianov.ScoutIP` container for the app's own SwiftData mirroring, so it no longer matched the entitlements. The `Archive` step kept working because it signs with `-allowProvisioningUpdates`, letting Xcode regenerate a matching profile on the fly.

This switches the export to the same automatic signing approach so Xcode regenerates a profile that matches whatever the entitlements declare, removing the dependency on the hand-exported profile secret. `ExportOptions.plist` now uses `automatic` signing and the modern `app-store-connect` method, and the export command passes the App Store Connect API key alongside `-allowProvisioningUpdates`. The iCloud containers in the entitlements are left untouched so Scout's CloudKit backend can be brought back without further signing changes.