### PR TITLE
Revert TestFlight export to manual signing

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -90,10 +90,6 @@ jobs:
             -archivePath $RUNNER_TEMP/ScoutIP.xcarchive \
             -exportOptionsPlist ExportOptions.plist \
             -exportPath $RUNNER_TEMP/export \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath ~/private_keys/AuthKey_$APP_STORE_CONNECT_KEY_ID.p8 \
-            -authenticationKeyID $APP_STORE_CONNECT_KEY_ID \
-            -authenticationKeyIssuerID $APP_STORE_CONNECT_ISSUER_ID \
             | xcbeautify
 
       - name: Upload to TestFlight

--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -3,11 +3,18 @@
 <plist version="1.0">
 <dict>
     <key>method</key>
-    <string>app-store-connect</string>
+    <string>app-store</string>
     <key>teamID</key>
     <string>CGU22629ZT</string>
     <key>signingStyle</key>
-    <string>automatic</string>
+    <string>manual</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>com.kasianov.ScoutIP</key>
+        <string>ScoutIP App Store</string>
+    </dict>
+    <key>signingCertificate</key>
+    <string>Apple Distribution</string>
     <key>uploadSymbols</key>
     <true/>
 </dict>


### PR DESCRIPTION
The automatic export signing introduced in #304 doesn't work in this setup: `xcodebuild -exportArchive` with `signingStyle: automatic` asks Apple to cloud-sign the IPA, and the App Store Connect API key isn't permitted to do that, so export fails with a `Cloud signing permission error`. The key can still create provisioning profiles during `Archive` (which is why that step passes), but cloud distribution signing is a separate permission it lacks.

Since CI already installs a local `Apple Distribution` certificate via the signing action, cloud signing isn't needed. This restores manual export signing with the `ScoutIP App Store` profile exactly as it was before #304.

This alone won't make the deploy green: the `PROVISIONING_PROFILE_BASE64` secret still holds a stale profile that predates the `iCloud.com.kasianov.ScoutIP` container added in #296. After merging, the profile needs to be regenerated to include that container and the secret updated, after which manual export will match the entitlements again.