### PR TITLE
Allow HTTP connections to the self-hosted Scout server

### DIFF
--- a/ScoutIP/Resources/Info.plist
+++ b/ScoutIP/Resources/Info.plist
@@ -4,6 +4,11 @@
 <dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>


### PR DESCRIPTION
The self-hosted Scout server is reached over plain HTTP by IP address (`SCOUT_IP`), and the app has no App Transport Security exception, so iOS blocks every request to it. This silently breaks analytics uploads from `Scout.setup` in all builds, and surfaces in the in-app dashboard as "The resource could not be loaded because the App Transport Security policy requires the use of a secure connection."

This adds an `NSAppTransportSecurity` exception with `NSAllowsArbitraryLoads` to the app's `Info.plist` so requests to the server are allowed.

Note that `NSAllowsArbitraryLoads` disables ATS globally and needs a justification at App Store review. If the server runs on a private/local network, `NSAllowsLocalNetworking` would be a tighter exception; the long-term fix is to serve it over HTTPS and drop the exception entirely.