### PR TITLE
Link Scout PR in dependency update commits

### DIFF
--- a/.github/workflows/update-dependency.yml
+++ b/.github/workflows/update-dependency.yml
@@ -29,13 +29,21 @@ jobs:
           if git diff --quiet; then
             echo "No dependency changes"
           else
-            SHA=$(jq -r '.pins[] | select(.identity == "scout") | .state.revision' ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved | cut -c1-7)
+            FULL_SHA=$(jq -r '.pins[] | select(.identity == "scout") | .state.revision' ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved)
+            SHA=$(echo "$FULL_SHA" | cut -c1-7)
+            # Link to the Scout PR that introduced this revision, falling back to the commit
+            SCOUT_PR_URL=$(gh api "repos/kasianov-mikhail/scout/commits/$FULL_SHA/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+            if [ -n "$SCOUT_PR_URL" ]; then
+              BODY="Scout PR: $SCOUT_PR_URL"
+            else
+              BODY="Scout commit: https://github.com/kasianov-mikhail/scout/commit/$FULL_SHA"
+            fi
             BRANCH="auto/update-scout-$(date +%s)"
             git checkout -b "$BRANCH"
             git add ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
-            git commit -m "Update Scout dependency to $SHA"
+            git commit -m "Update Scout dependency to $SHA" -m "$BODY"
             git push -u origin "$BRANCH"
-            gh pr create --title "Update Scout dependency to $SHA" --body "Triggered by Scout update" --head "$BRANCH" --base main
+            gh pr create --title "Update Scout dependency to $SHA" --body "$BODY" --head "$BRANCH" --base main
             # Mergeability is computed asynchronously, so poll until GitHub reports it
             for _ in {1..10}; do
               MERGEABLE=$(gh pr view "$BRANCH" --json mergeable --jq '.mergeable')
@@ -45,7 +53,7 @@ jobs:
             if [ "$MERGEABLE" = "CONFLICTING" ]; then
               gh pr close "$BRANCH" --comment "Closed due to merge conflicts" --delete-branch
             else
-              gh pr merge "$BRANCH" --auto --squash --delete-branch
+              gh pr merge "$BRANCH" --auto --squash --delete-branch --body "$BODY"
             fi
             gh pr list --state open --json number,headRefName \
               --jq '.[] | select(.headRefName | startswith("auto/update-scout-")) | select(.headRefName != "'"$BRANCH"'") | .number' \


### PR DESCRIPTION
The auto-generated "Update Scout dependency" commits only referenced the wrapper repo's own squash PR (such as #307), which is useless for understanding what actually changed in Scout. The Scout PR body that the workflow set previously never reached the merged commit, since this repo's squash setting keeps only the PR title.

This change resolves the Scout pull request that introduced the new revision through the GitHub API using the full revision SHA, and includes its URL in the commit body, falling back to a direct commit link when no PR is found. The link is passed to `gh pr merge --body` so it survives the squash and lands in the commit on `main`.

A merged commit will now read `Update Scout dependency to <sha> (#NNN)` with a `Scout PR: <url>` line in the body. Note this relies on `GH_PAT` having read access to the `scout` repository.