### PR TITLE
Reference Scout PR in the dependency update commit title

### DIFF
--- a/.github/workflows/update-dependency.yml
+++ b/.github/workflows/update-dependency.yml
@@ -31,19 +31,20 @@ jobs:
           else
             FULL_SHA=$(jq -r '.pins[] | select(.identity == "scout") | .state.revision' ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved)
             SHA=$(echo "$FULL_SHA" | cut -c1-7)
-            # Link to the Scout PR that introduced this revision, falling back to the commit
-            SCOUT_PR_URL=$(gh api "repos/kasianov-mikhail/scout/commits/$FULL_SHA/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
-            if [ -n "$SCOUT_PR_URL" ]; then
-              BODY="Scout PR: $SCOUT_PR_URL"
+            # Reference the Scout PR that introduced this revision in the title, falling back to the commit
+            PR_NUMBER=$(gh api "repos/kasianov-mikhail/scout/commits/$FULL_SHA/pulls" --jq '.[0].number // empty' 2>/dev/null || true)
+            if [ -n "$PR_NUMBER" ]; then
+              REF="kasianov-mikhail/scout#$PR_NUMBER"
             else
-              BODY="Scout commit: https://github.com/kasianov-mikhail/scout/commit/$FULL_SHA"
+              REF="kasianov-mikhail/scout@$SHA"
             fi
+            TITLE="Update Scout dependency to $SHA ($REF)"
             BRANCH="auto/update-scout-$(date +%s)"
             git checkout -b "$BRANCH"
             git add ScoutIP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
-            git commit -m "Update Scout dependency to $SHA" -m "$BODY"
+            git commit -m "$TITLE"
             git push -u origin "$BRANCH"
-            gh pr create --title "Update Scout dependency to $SHA" --body "$BODY" --head "$BRANCH" --base main
+            gh pr create --title "$TITLE" --body "" --head "$BRANCH" --base main
             # Mergeability is computed asynchronously, so poll until GitHub reports it
             for _ in {1..10}; do
               MERGEABLE=$(gh pr view "$BRANCH" --json mergeable --jq '.mergeable')
@@ -53,7 +54,7 @@ jobs:
             if [ "$MERGEABLE" = "CONFLICTING" ]; then
               gh pr close "$BRANCH" --comment "Closed due to merge conflicts" --delete-branch
             else
-              gh pr merge "$BRANCH" --auto --squash --delete-branch --body "$BODY"
+              gh pr merge "$BRANCH" --auto --squash --delete-branch
             fi
             gh pr list --state open --json number,headRefName \
               --jq '.[] | select(.headRefName | startswith("auto/update-scout-")) | select(.headRefName != "'"$BRANCH"'") | .number' \


### PR DESCRIPTION
The auto-generated Scout update commits previously carried the Scout PR link in the commit body. This moves it into the title using the compact cross-repo form `kasianov-mikhail/scout#NN` (falling back to `kasianov-mikhail/scout@<sha>` when the revision has no associated pull request) and drops the commit body entirely.

The result is a single-line commit on `main` such as `Update Scout dependency to bd2c6e8 (kasianov-mikhail/scout#142) (#NNN)`, where the Scout reference autolinks to the upstream PR and produces a back-reference there, while GitHub still appends the wrapper PR number on squash. Because no `--subject` is passed to `gh pr merge`, that automatic `(#NNN)` suffix is preserved, and the single one-line commit keeps the squashed body empty.