### PR TITLE
Display all README badges on a single line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 # Scout IP
 
-[![Build Matrix](https://github.com/kasianov-mikhail/scout-ip/actions/workflows/build-matrix.yml/badge.svg)](https://github.com/kasianov-mikhail/scout-ip/actions/workflows/build-matrix.yml)
-[![TestFlight](https://github.com/kasianov-mikhail/scout-ip/actions/workflows/testflight.yml/badge.svg)](https://github.com/kasianov-mikhail/scout-ip/actions/workflows/testflight.yml)
-
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-![Platform](https://img.shields.io/badge/platform-iOS%2017%2B-blue)
-![Swift](https://img.shields.io/badge/Swift-6.0-orange)
+[![Build Matrix](https://github.com/kasianov-mikhail/scout-ip/actions/workflows/build-matrix.yml/badge.svg)](https://github.com/kasianov-mikhail/scout-ip/actions/workflows/build-matrix.yml) [![TestFlight](https://github.com/kasianov-mikhail/scout-ip/actions/workflows/testflight.yml/badge.svg)](https://github.com/kasianov-mikhail/scout-ip/actions/workflows/testflight.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) ![Platform](https://img.shields.io/badge/platform-iOS%2017%2B-blue) ![Swift](https://img.shields.io/badge/Swift-6.0-orange)
 
 
 A companion app for the [Scout](https://github.com/kasianov-mikhail/scout) package. Scout IP uses your device's public IP address to generate real-world logs, metrics, and activity data — providing a live environment to test and verify Scout's features through its built-in dashboard.


### PR DESCRIPTION
The status badges at the top of the README were previously split across two lines, with the GitHub Actions badges separated from the shields.io badges by a blank line. This combines all five badges (`Build Matrix`, `TestFlight`, `License: MIT`, `Platform`, and `Swift`) into a single line so they render as one continuous row.